### PR TITLE
Add advanced toolchain support through `walrus`

### DIFF
--- a/BINARY.md
+++ b/BINARY.md
@@ -66,21 +66,8 @@ many types are in the subsection. Each type is encoded as:
 type := params:vec(valtype) results:vec(valtype)
 ```
 
-And value types are encoded as:
-
-```
-valtype := 0x00     # string
-         | 0x01     # s8
-         | 0x02     # s16
-         | 0x03     # s32
-         | 0x04     # s64
-         | 0x05     # u8
-         | 0x06     # u16
-         | 0x07     # u32
-         | 0x08     # u64
-         | 0x09     # f32
-         | 0x0a     # f64
-```
+Value type encodings are best consulted by looking at the source, namely the
+`wit-writer` and `wit-parser` crates.
 
 ## Import Subsection (1)
 
@@ -168,10 +155,5 @@ type signature must match `core-func`'s type signature.
 
 ## Instructions
 
-Instruction encodings look like:
-
-```
-instr := 0x00 param:u32      # arg.get $param
-      |  0x01 id:u32         # call-core $func
-      |  0x02                # end
-```
+Instruction encodings are best consulted by looking at the source, namely the
+`wit-writer` and `wit-parser` crates.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,4 +12,4 @@ members = [
 ]
 
 [patch.crates-io]
-walrus = { git = 'https://github.com/alexcrichton/walrus', branch = 'custom-section-roots' }
+walrus = { git = 'https://github.com/rustwasm/walrus' }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,4 +8,8 @@ edition = "2018"
 members = [
   'crates/text',
   'crates/printer',
+  'crates/walrus',
 ]
+
+[patch.crates-io]
+walrus = { git = 'https://github.com/alexcrichton/walrus', branch = 'custom-section-roots' }

--- a/README.md
+++ b/README.md
@@ -35,12 +35,19 @@ Functionality provided by this project currently is:
 * `crates/parser` - a Rust library which parses the binary format for wasm
   interface types
 
+* `crates/writer` - a Rust library which is a raw interface for writing the
+  binary format of wasm interface types
+
 * `crates/validator` - a Rust library which performs validation over a wasm
   module which contains wasm interface types, specifically focusing on the wasm
   interface types section.
 
 * `crates/printer` - a Rust library which will print the binary representation
   of a wasm interface types `*.wasm` blob into its textual format.
+
+* `crates/walrus` - an implementation of a custom section type for the `walrus`
+  Rust crate, useful for more advanced transformation on interface type
+  sections.
 
 The current state of the binary encoding as well as some semantic nodes are
 located in [`BINARY.md`](BINARY.md) as well as [`SEMANTICS.md`](SEMANTICS.md).

--- a/crates/parser/src/lib.rs
+++ b/crates/parser/src/lib.rs
@@ -274,17 +274,17 @@ pub enum ValType {
 impl<'a> Parse<'a> for ValType {
     fn parse(parser: &mut Parser<'a>) -> Result<ValType> {
         Ok(match parser.parse::<u8>()? {
-            0 => ValType::String,
-            1 => ValType::S8,
-            2 => ValType::S16,
-            3 => ValType::S32,
-            4 => ValType::S64,
-            5 => ValType::U8,
-            6 => ValType::U16,
-            7 => ValType::U32,
-            8 => ValType::U64,
-            9 => ValType::F32,
-            10 => ValType::F64,
+            0 => ValType::S8,
+            1 => ValType::S16,
+            2 => ValType::S32,
+            3 => ValType::S64,
+            4 => ValType::U8,
+            5 => ValType::U16,
+            6 => ValType::U32,
+            7 => ValType::U64,
+            8 => ValType::F32,
+            9 => ValType::F64,
+            10 => ValType::String,
             n => return Err(parser.error(ErrorKind::InvalidValType(n))),
         })
     }

--- a/crates/printer/Cargo.toml
+++ b/crates/printer/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2018"
 anyhow = "1.0"
 wasmprinter = "0.2"
 wit-parser = { path = "../parser" }
+wit-schema-version = { path = "../schema-version" }
 
 [dev-dependencies]
 getopts = "0.2"

--- a/crates/printer/src/lib.rs
+++ b/crates/printer/src/lib.rs
@@ -19,7 +19,7 @@ pub fn print_bytes(wasm: impl AsRef<[u8]>) -> anyhow::Result<String> {
 
 fn _print_bytes(wasm: &[u8]) -> anyhow::Result<String> {
     let mut printer = Printer::new();
-    printer.add_custom_section_printer("wasm-interface-types", print_wit);
+    printer.add_custom_section_printer(wit_schema_version::SECTION_NAME, print_wit);
     printer.print(wasm)
 }
 

--- a/crates/schema-version/src/lib.rs
+++ b/crates/schema-version/src/lib.rs
@@ -1,1 +1,2 @@
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");
+pub const SECTION_NAME: &str = "wasm-interface-types";

--- a/crates/text/Cargo.toml
+++ b/crates/text/Cargo.toml
@@ -6,18 +6,19 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1.0"
-leb128 = "0.2"
 wast = "3.0.4"
-wit-schema-version = { path = "../schema-version" }
+wit-writer = { path = "../writer" }
 
 [dev-dependencies]
 getopts = "0.2"
 test-helpers = { path = "../test-helpers" }
+walrus = "0.13.0"
 wasmparser = "0.42"
 wat = "1.0"
 wit-parser = { path = "../parser" }
 wit-printer = { path = "../printer" }
 wit-validator = { path = "../validator" }
+wit-walrus = { path = "../walrus" }
 
 [[test]]
 name = "all"

--- a/crates/text/src/ast/instr.rs
+++ b/crates/text/src/ast/instr.rs
@@ -3,7 +3,7 @@ use wast::parser::{Parse, Parser, Result};
 macro_rules! instructions {
     ($(#[$a:meta])* pub enum Instruction<'a> {
         $(
-            $name:ident $(($($arg:tt)*))? : [$($binary:tt)*] : $instr:tt,
+            $name:ident $(($($arg:tt)*))? : $instr:tt,
         )*
     }) => (
         $(#[$a])*
@@ -36,23 +36,6 @@ macro_rules! instructions {
                 parse_remainder(parser)
             }
         }
-
-        impl crate::binary::Encode for Instruction<'_> {
-            #[allow(non_snake_case)]
-            fn encode(&self, v: &mut Vec<u8>) {
-                match self {
-                    $(
-                        Instruction::$name $((instructions!(@first $($arg)*)))? => {
-                            fn encode<'a>($(arg: &$($arg)*,)? v: &mut Vec<u8>) {
-                                v.extend_from_slice(&[$($binary)*]);
-                                $(<$($arg)* as crate::binary::Encode>::encode(arg, v);)?
-                            }
-                            encode($( instructions!(@first $($arg)*), )? v)
-                        }
-                    )*
-                }
-            }
-        }
     );
 
     (@first $first:ident $($t:tt)*) => ($first);
@@ -62,56 +45,55 @@ instructions! {
     /// List of instructions in adapter functions.
     #[allow(missing_docs)]
     pub enum Instruction<'a> {
-        ArgGet(wast::Index<'a>) : [0x00] : "arg.get",
-        CallCore(wast::Index<'a>) : [0x01] : "call-core",
-        End : [0x02] : "end",
-        MemoryToString(MemoryToString<'a>) : [0x03] : "memory-to-string",
-        StringToMemory(StringToMemory<'a>) : [0x04] : "string-to-memory",
-        CallAdapter(wast::Index<'a>) : [0x05] : "call-adapter",
-        DeferCallCore(wast::Index<'a>) : [0x06] : "defer-call-core",
+        ArgGet(wast::Index<'a>) : "arg.get",
+        CallCore(wast::Index<'a>) : "call-core",
+        MemoryToString(MemoryToString<'a>) : "memory-to-string",
+        StringToMemory(StringToMemory<'a>) : "string-to-memory",
+        CallAdapter(wast::Index<'a>) : "call-adapter",
+        DeferCallCore(wast::Index<'a>) : "defer-call-core",
 
-        I32ToS8 : [0x07] : "i32-to-s8",
-        I32ToS8X : [0x08] : "i32-to-s8x",
-        I32ToU8 : [0x09] : "i32-to-u8",
-        I32ToS16 : [0x0a] : "i32-to-s16",
-        I32ToS16X : [0x0b] : "i32-to-s16x",
-        I32ToU16 : [0x0c] : "i32-to-u16",
-        I32ToS32 : [0x0d] : "i32-to-s32",
-        I32ToU32 : [0x0e] : "i32-to-u32",
-        I32ToS64 : [0x0f] : "i32-to-s64",
-        I32ToU64 : [0x10] : "i32-to-u64",
+        I32ToS8 : "i32-to-s8",
+        I32ToS8X : "i32-to-s8x",
+        I32ToU8 : "i32-to-u8",
+        I32ToS16 : "i32-to-s16",
+        I32ToS16X : "i32-to-s16x",
+        I32ToU16 : "i32-to-u16",
+        I32ToS32 : "i32-to-s32",
+        I32ToU32 : "i32-to-u32",
+        I32ToS64 : "i32-to-s64",
+        I32ToU64 : "i32-to-u64",
 
-        I64ToS8 : [0x11] : "i64-to-s8",
-        I64ToS8X : [0x12] : "i64-to-s8x",
-        I64ToU8 : [0x13] : "i64-to-u8",
-        I64ToS16 : [0x14] : "i64-to-s16",
-        I64ToS16X : [0x15] : "i64-to-s16x",
-        I64ToU16 : [0x16] : "i64-to-u16",
-        I64ToS32 : [0x17] : "i64-to-s32",
-        I64ToS32X : [0x18] : "i64-to-s32x",
-        I64ToU32 : [0x19] : "i64-to-u32",
-        I64ToS64 : [0x1a] : "i64-to-s64",
-        I64ToU64 : [0x1b] : "i64-to-u64",
+        I64ToS8 : "i64-to-s8",
+        I64ToS8X : "i64-to-s8x",
+        I64ToU8 : "i64-to-u8",
+        I64ToS16 : "i64-to-s16",
+        I64ToS16X : "i64-to-s16x",
+        I64ToU16 : "i64-to-u16",
+        I64ToS32 : "i64-to-s32",
+        I64ToS32X : "i64-to-s32x",
+        I64ToU32 : "i64-to-u32",
+        I64ToS64 : "i64-to-s64",
+        I64ToU64 : "i64-to-u64",
 
-        S8ToI32 : [0x1c] : "s8-to-i32",
-        U8ToI32 : [0x1d] : "u8-to-i32",
-        S16ToI32 : [0x1e] : "s16-to-i32",
-        U16ToI32 : [0x1f] : "u16-to-i32",
-        S32ToI32 : [0x20] : "s32-to-i32",
-        U32ToI32 : [0x21] : "u32-to-i32",
-        S64ToI32 : [0x22] : "s64-to-i32",
-        S64ToI32X : [0x23] : "s64-to-i32x",
-        U64ToI32 : [0x24] : "u64-to-i32",
-        U64ToI32X : [0x25] : "u64-to-i32x",
+        S8ToI32 : "s8-to-i32",
+        U8ToI32 : "u8-to-i32",
+        S16ToI32 : "s16-to-i32",
+        U16ToI32 : "u16-to-i32",
+        S32ToI32 : "s32-to-i32",
+        U32ToI32 : "u32-to-i32",
+        S64ToI32 : "s64-to-i32",
+        S64ToI32X : "s64-to-i32x",
+        U64ToI32 : "u64-to-i32",
+        U64ToI32X : "u64-to-i32x",
 
-        S8ToI64 : [0x26] : "s8-to-i64",
-        U8ToI64 : [0x27] : "u8-to-i64",
-        S16ToI64 : [0x28] : "s16-to-i64",
-        U16ToI64 : [0x29] : "u16-to-i64",
-        S32ToI64 : [0x2a] : "s32-to-i64",
-        U32ToI64 : [0x2b] : "u32-to-i64",
-        S64ToI64 : [0x2c] : "s64-to-i64",
-        U64ToI64 : [0x2d] : "u64-to-i64",
+        S8ToI64 : "s8-to-i64",
+        U8ToI64 : "u8-to-i64",
+        S16ToI64 : "s16-to-i64",
+        U16ToI64 : "u16-to-i64",
+        S32ToI64 : "s32-to-i64",
+        U32ToI64 : "u32-to-i64",
+        S64ToI64 : "s64-to-i64",
+        U64ToI64 : "u64-to-i64",
     }
 }
 

--- a/crates/text/src/ast/module.rs
+++ b/crates/text/src/ast/module.rs
@@ -35,7 +35,7 @@ impl Module<'_> {
         };
         crate::resolve::resolve(core, &mut self.adapters, &names)?;
         let mut core = self.core.encode()?;
-        core.extend_from_slice(&crate::binary::encode(&self.adapters));
+        crate::binary::append(&self.adapters, &mut core);
         Ok(core)
     }
 }

--- a/crates/walrus/Cargo.toml
+++ b/crates/walrus/Cargo.toml
@@ -1,11 +1,13 @@
 [package]
-name = "wit-validator"
+name = "wit-walrus"
 version = "0.1.0"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 edition = "2018"
 
 [dependencies]
 anyhow = "1.0"
-wasmparser = "0.42"
+id-arena = "2"
+walrus = "0.13"
 wit-parser = { path = "../parser" }
 wit-schema-version = { path = "../schema-version" }
+wit-writer = { path = "../writer" }

--- a/crates/walrus/src/exports.rs
+++ b/crates/walrus/src/exports.rs
@@ -1,0 +1,85 @@
+use crate::{FuncId, WasmInterfaceTypes, WitIdsToIndices, WitIndicesToIds};
+use anyhow::Result;
+use id_arena::{Arena, Id};
+
+#[derive(Debug, Default)]
+pub struct Exports {
+    arena: Arena<Export>,
+}
+
+#[derive(Debug)]
+pub struct Export {
+    id: ExportId,
+    pub name: String,
+    pub func: FuncId,
+}
+
+pub type ExportId = Id<Export>;
+
+impl WasmInterfaceTypes {
+    pub(crate) fn parse_exports(
+        &mut self,
+        exports: wit_parser::Exports,
+        wids: &mut WitIndicesToIds,
+    ) -> Result<()> {
+        for export in exports {
+            let export = export?;
+            let func = wids.func(export.func)?;
+            self.exports.add(export.name, func);
+        }
+        Ok(())
+    }
+
+    pub(crate) fn encode_exports(&self, writer: &mut wit_writer::Writer, wids: &WitIdsToIndices) {
+        let mut w = writer.exports(self.exports.arena.len() as u32);
+        for export in self.exports.iter() {
+            w.add(&export.name, wids.func(export.func));
+        }
+    }
+}
+
+impl Exports {
+    /// Gets a reference to an export given its id
+    pub fn get(&self, id: ExportId) -> &Export {
+        &self.arena[id]
+    }
+
+    /// Gets a reference to an export given its id
+    pub fn get_mut(&mut self, id: ExportId) -> &mut Export {
+        &mut self.arena[id]
+    }
+
+    // /// Removes an export from this module.
+    // ///
+    // /// It is up to you to ensure that any potential references to the deleted
+    // /// export are also removed, eg `get_global` expressions.
+    // pub fn delete(&mut self, id: ExportId) {
+    //     self.arena.delete(id);
+    // }
+
+    /// Get a shared reference to this section's exports.
+    pub fn iter(&self) -> impl Iterator<Item = &Export> {
+        self.arena.iter().map(|(_, f)| f)
+    }
+
+    /// Get mutable references to this section's exports.
+    pub fn iter_mut(&mut self) -> impl Iterator<Item = &mut Export> {
+        self.arena.iter_mut().map(|(_, f)| f)
+    }
+
+    /// Adds a new export to this section
+    pub fn add(&mut self, name: &str, func: FuncId) -> ExportId {
+        self.arena.alloc_with_id(|id| Export {
+            id,
+            name: name.to_string(),
+            func,
+        })
+    }
+}
+
+impl Export {
+    /// Returns the identifier for this `Export`
+    pub fn id(&self) -> ExportId {
+        self.id
+    }
+}

--- a/crates/walrus/src/funcs.rs
+++ b/crates/walrus/src/funcs.rs
@@ -1,0 +1,320 @@
+use crate::WitIdsToIndices;
+use crate::{ImportId, TypeId, ValType, WasmInterfaceTypes, WitIndicesToIds};
+use anyhow::Result;
+use id_arena::{Arena, Id};
+use walrus::IndicesToIds;
+
+#[derive(Debug, Default)]
+pub struct Funcs {
+    arena: Arena<Func>,
+}
+
+#[derive(Debug)]
+pub struct Func {
+    id: FuncId,
+    pub ty: TypeId,
+    pub kind: FuncKind,
+}
+
+#[derive(Debug)]
+pub enum FuncKind {
+    Import(ImportId),
+    Local(Vec<Instruction>),
+}
+
+#[derive(Debug)]
+pub enum Instruction {
+    CallCore(walrus::FunctionId),
+    DeferCallCore(walrus::FunctionId),
+    CallAdapter(FuncId),
+    ArgGet(u32),
+    MemoryToString(walrus::MemoryId),
+    StringToMemory {
+        mem: walrus::MemoryId,
+        malloc: walrus::FunctionId,
+    },
+    IntToWasm {
+        input: ValType,
+        output: walrus::ValType,
+        trap: bool,
+    },
+    WasmToInt {
+        input: walrus::ValType,
+        output: ValType,
+        trap: bool,
+    },
+}
+
+pub type FuncId = Id<Func>;
+
+impl WasmInterfaceTypes {
+    pub(crate) fn parse_funcs(
+        &mut self,
+        funcs: wit_parser::Funcs,
+        ids: &IndicesToIds,
+        wids: &mut WitIndicesToIds,
+    ) -> Result<()> {
+        // assign an id to everything first ...
+        let mut instrs = Vec::new();
+        for func in funcs {
+            let func = func?;
+            let ty = wids.ty(func.ty)?;
+            let id = self.funcs.add_local(ty, Vec::new());
+            wids.funcs.push(id);
+            instrs.push((id, func.instrs()));
+        }
+
+        // ... and then parse all the instructions
+        for (id, instrs) in instrs {
+            let mut list = Vec::new();
+            for instr in instrs {
+                use wit_parser::Instruction as R; // "raw"
+                use Instruction as W; // "walrus"
+                use walrus::ValType as RVT; // "raw value type"
+                use crate::ValType as VT;
+
+                fn w2i(input: walrus::ValType, output: ValType, trap: bool) -> W {
+                    W::WasmToInt { input, output, trap }
+                }
+
+                fn i2w(input: ValType, output: walrus::ValType, trap: bool) -> W {
+                    W::IntToWasm { input, output, trap }
+                }
+
+                list.push(match instr? {
+                    R::CallCore(id) => W::CallCore(ids.get_func(id)?),
+                    R::CallAdapter(id) => W::CallAdapter(wids.func(id)?),
+                    R::ArgGet(idx) => W::ArgGet(idx),
+                    R::MemoryToString(mem) => W::MemoryToString(ids.get_memory(mem)?),
+                    R::StringToMemory(args) => W::StringToMemory {
+                        mem: ids.get_memory(args.mem)?,
+                        malloc: ids.get_func(args.malloc)?,
+                    },
+                    R::DeferCallCore(id) => W::DeferCallCore(ids.get_func(id)?),
+
+                    R::I32ToS8 => w2i(RVT::I32, VT::S8, false),
+                    R::I32ToS8X => w2i(RVT::I32, VT::S8, true),
+                    R::I32ToU8 => w2i(RVT::I32, VT::U8, false),
+                    R::I32ToS16 => w2i(RVT::I32, VT::S16, false),
+                    R::I32ToS16X => w2i(RVT::I32, VT::S16, true),
+                    R::I32ToU16 => w2i(RVT::I32, VT::U16, false),
+                    R::I32ToS32 => w2i(RVT::I32, VT::S32, false),
+                    R::I32ToU32 => w2i(RVT::I32, VT::U32, false),
+                    R::I32ToS64 => w2i(RVT::I32, VT::S64, false),
+                    R::I32ToU64 => w2i(RVT::I32, VT::U64, false),
+
+                    R::I64ToS8 => w2i(RVT::I64, VT::S8, false),
+                    R::I64ToS8X => w2i(RVT::I64, VT::S8, true),
+                    R::I64ToU8 => w2i(RVT::I64, VT::U8, false),
+                    R::I64ToS16 => w2i(RVT::I64, VT::S16, false),
+                    R::I64ToS16X => w2i(RVT::I64, VT::S16, true),
+                    R::I64ToU16 => w2i(RVT::I64, VT::U16, false),
+                    R::I64ToS32 => w2i(RVT::I64, VT::S32, false),
+                    R::I64ToS32X => w2i(RVT::I64, VT::S32, true),
+                    R::I64ToU32 => w2i(RVT::I64, VT::U32, false),
+                    R::I64ToS64 => w2i(RVT::I64, VT::S64, false),
+                    R::I64ToU64 => w2i(RVT::I64, VT::U64, false),
+
+                    R::S8ToI32 => i2w(VT::S8, RVT::I32, false),
+                    R::U8ToI32 => i2w(VT::U8, RVT::I32, false),
+                    R::S16ToI32 => i2w(VT::S16, RVT::I32, false),
+                    R::U16ToI32 => i2w(VT::U16, RVT::I32, false),
+                    R::S32ToI32 => i2w(VT::S32, RVT::I32, false),
+                    R::U32ToI32 => i2w(VT::U32, RVT::I32, false),
+                    R::S64ToI32 => i2w(VT::S64, RVT::I32, false),
+                    R::S64ToI32X => i2w(VT::S64, RVT::I32, true),
+                    R::U64ToI32 => i2w(VT::U64, RVT::I32, false),
+                    R::U64ToI32X => i2w(VT::U64, RVT::I32, true),
+
+                    R::S8ToI64 => i2w(VT::S8, RVT::I64, false),
+                    R::U8ToI64 => i2w(VT::U8, RVT::I64, false),
+                    R::S16ToI64 => i2w(VT::S16, RVT::I64, false),
+                    R::U16ToI64 => i2w(VT::U16, RVT::I64, false),
+                    R::S32ToI64 => i2w(VT::S32, RVT::I64, false),
+                    R::U32ToI64 => i2w(VT::U32, RVT::I64, false),
+                    R::S64ToI64 => i2w(VT::S64, RVT::I64, false),
+                    R::U64ToI64 => i2w(VT::U64, RVT::I64, false),
+
+                    R::End => continue,
+                });
+            }
+
+            match &mut self.funcs.arena.get_mut(id).unwrap().kind {
+                FuncKind::Local(i) => *i = list,
+                _ => unreachable!(),
+            }
+        }
+
+        Ok(())
+    }
+
+    pub(crate) fn encode_funcs(
+        &self,
+        writer: &mut wit_writer::Writer,
+        wids: &mut WitIdsToIndices,
+        ids: &walrus::IdsToIndices,
+    ) {
+        // Filter out imported functions since those went in the import section
+        let funcs = self
+            .funcs
+            .iter()
+            .filter_map(|f| match &f.kind {
+                FuncKind::Local(instrs) => Some((f, instrs)),
+                FuncKind::Import(_) => None,
+            })
+            .collect::<Vec<_>>();
+
+        // Assign an index for all functions first so inter-function references
+        // work.
+        for (func, _) in funcs.iter() {
+            wids.push_func(func.id());
+        }
+
+        let mut w = writer.funcs(funcs.len() as u32);
+        for (func, instrs) in funcs {
+            let mut w = w.add(wids.ty(func.ty));
+            for instr in instrs {
+                use Instruction::*;
+                match *instr {
+                    ArgGet(n) => w.arg_get(n),
+                    CallCore(f) => w.call_core(ids.get_func_index(f)),
+                    DeferCallCore(f) => w.defer_call_core(ids.get_func_index(f)),
+                    CallAdapter(f) => w.call_adapter(wids.func(f)),
+                    MemoryToString(m) => w.memory_to_string(ids.get_memory_index(m)),
+                    StringToMemory { mem, malloc } => {
+                        w.string_to_memory(ids.get_func_index(malloc), ids.get_memory_index(mem));
+                    }
+                    IntToWasm {
+                        input,
+                        output,
+                        trap,
+                    } => i2w(&mut w, input, output, trap),
+                    WasmToInt {
+                        input,
+                        output,
+                        trap,
+                    } => w2i(&mut w, input, output, trap),
+                }
+            }
+        }
+        fn w2i(
+            w: &mut wit_writer::Instructions<'_, '_>,
+            input: walrus::ValType,
+            output: ValType,
+            trap: bool,
+        ) {
+            match (input, output, trap) {
+                (walrus::ValType::I32, ValType::S8, false) => w.i32_to_s8(),
+                (walrus::ValType::I32, ValType::S8, true) => w.i32_to_s8x(),
+                (walrus::ValType::I32, ValType::U8, _) => w.i32_to_u8(),
+                (walrus::ValType::I32, ValType::S16, false) => w.i32_to_s16(),
+                (walrus::ValType::I32, ValType::S16, true) => w.i32_to_s16x(),
+                (walrus::ValType::I32, ValType::U16, _) => w.i32_to_u16(),
+                (walrus::ValType::I32, ValType::S32, _) => w.i32_to_s32(),
+                (walrus::ValType::I32, ValType::U32, _) => w.i32_to_u32(),
+                (walrus::ValType::I32, ValType::S64, _) => w.i32_to_s64(),
+                (walrus::ValType::I32, ValType::U64, _) => w.i32_to_u64(),
+
+                (walrus::ValType::I64, ValType::S8, false) => w.i64_to_s8(),
+                (walrus::ValType::I64, ValType::S8, true) => w.i64_to_s8x(),
+                (walrus::ValType::I64, ValType::U8, _) => w.i64_to_u8(),
+                (walrus::ValType::I64, ValType::S16, false) => w.i64_to_s16(),
+                (walrus::ValType::I64, ValType::S16, true) => w.i64_to_s16x(),
+                (walrus::ValType::I64, ValType::U16, _) => w.i64_to_u16(),
+                (walrus::ValType::I64, ValType::S32, false) => w.i64_to_s32(),
+                (walrus::ValType::I64, ValType::S32, true) => w.i64_to_s32x(),
+                (walrus::ValType::I64, ValType::U32, _) => w.i64_to_u32(),
+                (walrus::ValType::I64, ValType::S64, _) => w.i64_to_s64(),
+                (walrus::ValType::I64, ValType::U64, _) => w.i64_to_u64(),
+
+                _ => unreachable!(),
+            }
+        }
+
+        fn i2w(
+            w: &mut wit_writer::Instructions<'_, '_>,
+            input: ValType,
+            output: walrus::ValType,
+            trap: bool,
+        ) {
+            match (input, output, trap) {
+                (ValType::S8, walrus::ValType::I32, _) => w.s8_to_i32(),
+                (ValType::U8, walrus::ValType::I32, _) => w.u8_to_i32(),
+                (ValType::S16, walrus::ValType::I32, _) => w.s16_to_i32(),
+                (ValType::U16, walrus::ValType::I32, _) => w.u16_to_i32(),
+                (ValType::S32, walrus::ValType::I32, _) => w.s32_to_i32(),
+                (ValType::U32, walrus::ValType::I32, _) => w.u32_to_i32(),
+                (ValType::S64, walrus::ValType::I32, false) => w.s64_to_i32(),
+                (ValType::S64, walrus::ValType::I32, true) => w.s64_to_i32x(),
+                (ValType::U64, walrus::ValType::I32, false) => w.u64_to_i32(),
+                (ValType::U64, walrus::ValType::I32, true) => w.u64_to_i32x(),
+
+                (ValType::S8, walrus::ValType::I64, _) => w.s8_to_i64(),
+                (ValType::U8, walrus::ValType::I64, _) => w.u8_to_i64(),
+                (ValType::S16, walrus::ValType::I64, _) => w.s16_to_i64(),
+                (ValType::U16, walrus::ValType::I64, _) => w.u16_to_i64(),
+                (ValType::S32, walrus::ValType::I64, _) => w.s32_to_i64(),
+                (ValType::U32, walrus::ValType::I64, _) => w.u32_to_i64(),
+                (ValType::S64, walrus::ValType::I64, _) => w.s64_to_i64(),
+                (ValType::U64, walrus::ValType::I64, _) => w.u64_to_i64(),
+
+                _ => unreachable!(),
+            }
+        }
+    }
+}
+
+impl Funcs {
+    /// Gets a reference to an func given its id
+    pub fn get(&self, id: FuncId) -> &Func {
+        &self.arena[id]
+    }
+
+    /// Gets a reference to an func given its id
+    pub fn get_mut(&mut self, id: FuncId) -> &mut Func {
+        &mut self.arena[id]
+    }
+
+    // /// Removes an func from this module.
+    // ///
+    // /// It is up to you to ensure that any potential references to the deleted
+    // /// func are also removed, eg `get_global` expressions.
+    // pub fn delete(&mut self, id: FuncId) {
+    //     self.arena.delete(id);
+    // }
+
+    /// Get a shared reference to this section's funcs.
+    pub fn iter(&self) -> impl Iterator<Item = &Func> {
+        self.arena.iter().map(|(_, f)| f)
+    }
+
+    /// Get mutable references to this section's funcs.
+    pub fn iter_mut(&mut self) -> impl Iterator<Item = &mut Func> {
+        self.arena.iter_mut().map(|(_, f)| f)
+    }
+
+    /// Create a new externally defined, imported function.
+    pub fn add_import(&mut self, ty: TypeId, import: ImportId) -> FuncId {
+        self.arena.alloc_with_id(|id| Func {
+            id,
+            ty,
+            kind: FuncKind::Import(import),
+        })
+    }
+
+    /// Adds a new local func to this section
+    pub fn add_local(&mut self, ty: TypeId, instrs: Vec<Instruction>) -> FuncId {
+        self.arena.alloc_with_id(|id| Func {
+            id,
+            ty,
+            kind: FuncKind::Local(instrs),
+        })
+    }
+}
+
+impl Func {
+    /// Returns the identifier for this `Func`
+    pub fn id(&self) -> FuncId {
+        self.id
+    }
+}

--- a/crates/walrus/src/funcs.rs
+++ b/crates/walrus/src/funcs.rs
@@ -22,7 +22,7 @@ pub enum FuncKind {
     Local(Vec<Instruction>),
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum Instruction {
     CallCore(walrus::FunctionId),
     DeferCallCore(walrus::FunctionId),

--- a/crates/walrus/src/implements.rs
+++ b/crates/walrus/src/implements.rs
@@ -1,0 +1,98 @@
+use crate::{FuncId, WasmInterfaceTypes, WitIndicesToIds, WitIdsToIndices};
+use anyhow::Result;
+use id_arena::{Arena, Id};
+use walrus::IndicesToIds;
+
+#[derive(Debug, Default)]
+pub struct Implements {
+    arena: Arena<Implement>,
+}
+
+#[derive(Debug)]
+pub struct Implement {
+    id: ImplementId,
+    pub adapter_func: FuncId,
+    pub core_func: walrus::FunctionId,
+}
+
+pub type ImplementId = Id<Implement>;
+
+impl WasmInterfaceTypes {
+    pub(crate) fn parse_implements(
+        &mut self,
+        implements: wit_parser::Implements,
+        ids: &IndicesToIds,
+        wids: &mut WitIndicesToIds,
+    ) -> Result<()> {
+        for implement in implements {
+            let implement = implement?;
+            self.implements.add(
+                wids.func(implement.adapter_func)?,
+                ids.get_func(implement.core_func)?,
+            );
+        }
+
+        Ok(())
+    }
+
+    pub(crate) fn encode_implements(
+        &self,
+        writer: &mut wit_writer::Writer,
+        wids: &WitIdsToIndices,
+        ids: &walrus::IdsToIndices,
+    ) {
+        let mut w = writer.implements(self.implements.arena.len() as u32);
+        for implement in self.implements.iter() {
+            w.add(
+                ids.get_func_index(implement.core_func),
+                wids.func(implement.adapter_func),
+            );
+        }
+    }
+}
+
+impl Implements {
+    /// Gets a reference to an implement given its id
+    pub fn get(&self, id: ImplementId) -> &Implement {
+        &self.arena[id]
+    }
+
+    /// Gets a reference to an implement given its id
+    pub fn get_mut(&mut self, id: ImplementId) -> &mut Implement {
+        &mut self.arena[id]
+    }
+
+    // /// Removes an implement from this module.
+    // ///
+    // /// It is up to you to ensure that any potential references to the deleted
+    // /// implement are also removed, eg `get_global` expressions.
+    // pub fn delete(&mut self, id: ImplementId) {
+    //     self.arena.delete(id);
+    // }
+
+    /// Get a shared reference to this section's implements.
+    pub fn iter(&self) -> impl Iterator<Item = &Implement> {
+        self.arena.iter().map(|(_, f)| f)
+    }
+
+    /// Get mutable references to this section's implements.
+    pub fn iter_mut(&mut self) -> impl Iterator<Item = &mut Implement> {
+        self.arena.iter_mut().map(|(_, f)| f)
+    }
+
+    /// Adds a new implement to this section
+    pub fn add(&mut self, adapter_func: FuncId, core_func: walrus::FunctionId) -> ImplementId {
+        self.arena.alloc_with_id(|id| Implement {
+            id,
+            core_func,
+            adapter_func,
+        })
+    }
+}
+
+impl Implement {
+    /// Returns the identifier for this `Implement`
+    pub fn id(&self) -> ImplementId {
+        self.id
+    }
+}

--- a/crates/walrus/src/implements.rs
+++ b/crates/walrus/src/implements.rs
@@ -1,4 +1,4 @@
-use crate::{FuncId, WasmInterfaceTypes, WitIndicesToIds, WitIdsToIndices};
+use crate::{FuncId, WasmInterfaceTypes, WitIdsToIndices, WitIndicesToIds};
 use anyhow::Result;
 use id_arena::{Arena, Id};
 use walrus::IndicesToIds;

--- a/crates/walrus/src/imports.rs
+++ b/crates/walrus/src/imports.rs
@@ -1,0 +1,95 @@
+use crate::{FuncId, WasmInterfaceTypes, WitIndicesToIds, WitIdsToIndices};
+use anyhow::Result;
+use id_arena::{Arena, Id};
+
+#[derive(Debug, Default)]
+pub struct Imports {
+    arena: Arena<Import>,
+}
+
+#[derive(Debug)]
+pub struct Import {
+    id: ImportId,
+    pub func: FuncId,
+    pub module: String,
+    pub name: String,
+}
+
+pub type ImportId = Id<Import>;
+
+impl WasmInterfaceTypes {
+    pub(crate) fn parse_imports(
+        &mut self,
+        imports: wit_parser::Imports,
+        wids: &mut WitIndicesToIds,
+    ) -> Result<()> {
+        for import in imports {
+            let import = import?;
+            let ty = wids.ty(import.ty)?;
+            let func = self.funcs.add_import(ty, self.imports.arena.next_id());
+            wids.funcs.push(func);
+            self.imports.add(import.module, import.name, func);
+        }
+        Ok(())
+    }
+
+    pub(crate) fn encode_imports(&self, writer: &mut wit_writer::Writer, wids: &mut WitIdsToIndices) {
+        let mut w = writer.imports(self.imports.arena.len() as u32);
+        for import in self.imports.iter() {
+            let ty = self.funcs.get(import.func).ty;
+            w.add(
+                &import.module,
+                &import.name,
+                wids.ty(ty),
+            );
+            wids.push_func(import.func);
+        }
+    }
+}
+
+impl Imports {
+    /// Gets a reference to an import given its id
+    pub fn get(&self, id: ImportId) -> &Import {
+        &self.arena[id]
+    }
+
+    /// Gets a reference to an import given its id
+    pub fn get_mut(&mut self, id: ImportId) -> &mut Import {
+        &mut self.arena[id]
+    }
+
+    // /// Removes an import from this module.
+    // ///
+    // /// It is up to you to ensure that any potential references to the deleted
+    // /// import are also removed, eg `get_global` expressions.
+    // pub fn delete(&mut self, id: ImportId) {
+    //     self.arena.delete(id);
+    // }
+
+    /// Get a shared reference to this section's imports.
+    pub fn iter(&self) -> impl Iterator<Item = &Import> {
+        self.arena.iter().map(|(_, f)| f)
+    }
+
+    /// Get mutable references to this section's imports.
+    pub fn iter_mut(&mut self) -> impl Iterator<Item = &mut Import> {
+        self.arena.iter_mut().map(|(_, f)| f)
+    }
+
+    /// Adds a new import to this section
+    pub fn add(&mut self, module: &str, name: &str, func: FuncId) -> ImportId {
+        self.arena.alloc_with_id(|id| Import {
+            id,
+            module: module.to_string(),
+            name: name.to_string(),
+            func,
+        })
+    }
+}
+
+impl Import {
+    /// Returns the identifier for this `Import`
+    pub fn id(&self) -> ImportId {
+        self.id
+    }
+}

--- a/crates/walrus/src/imports.rs
+++ b/crates/walrus/src/imports.rs
@@ -1,4 +1,4 @@
-use crate::{FuncId, WasmInterfaceTypes, WitIndicesToIds, WitIdsToIndices};
+use crate::{FuncId, WasmInterfaceTypes, WitIdsToIndices, WitIndicesToIds};
 use anyhow::Result;
 use id_arena::{Arena, Id};
 
@@ -33,15 +33,15 @@ impl WasmInterfaceTypes {
         Ok(())
     }
 
-    pub(crate) fn encode_imports(&self, writer: &mut wit_writer::Writer, wids: &mut WitIdsToIndices) {
+    pub(crate) fn encode_imports(
+        &self,
+        writer: &mut wit_writer::Writer,
+        wids: &mut WitIdsToIndices,
+    ) {
         let mut w = writer.imports(self.imports.arena.len() as u32);
         for import in self.imports.iter() {
             let ty = self.funcs.get(import.func).ty;
-            w.add(
-                &import.module,
-                &import.name,
-                wids.ty(ty),
-            );
+            w.add(&import.module, &import.name, wids.ty(ty));
             wids.push_func(import.func);
         }
     }

--- a/crates/walrus/src/lib.rs
+++ b/crates/walrus/src/lib.rs
@@ -40,7 +40,7 @@ impl CustomSection for WasmInterfaceTypes {
         writer.into_payload().into()
     }
 
-    fn gc_add_roots(&self, roots: &mut Roots) {
+    fn add_gc_roots(&self, roots: &mut Roots) {
         for i in self.implements.iter() {
             roots.push_func(i.core_func);
         }

--- a/crates/walrus/src/lib.rs
+++ b/crates/walrus/src/lib.rs
@@ -1,0 +1,148 @@
+use anyhow::{anyhow, Context, Result};
+use std::borrow::Cow;
+use std::collections::HashMap;
+use walrus::{passes::Roots, CustomSection, IdsToIndices, IndicesToIds, Module};
+use wit_schema_version::SECTION_NAME;
+
+#[derive(Debug, Default)]
+pub struct WasmInterfaceTypes {
+    pub types: Types,
+    pub imports: Imports,
+    pub implements: Implements,
+    pub exports: Exports,
+    pub funcs: Funcs,
+}
+
+mod exports;
+mod funcs;
+mod implements;
+mod imports;
+mod types;
+pub use self::exports::*;
+pub use self::funcs::*;
+pub use self::implements::*;
+pub use self::imports::*;
+pub use self::types::*;
+
+impl CustomSection for WasmInterfaceTypes {
+    fn name(&self) -> &str {
+        SECTION_NAME
+    }
+
+    fn data(&self, indices: &IdsToIndices) -> Cow<'_, [u8]> {
+        let mut writer = wit_writer::Writer::new();
+        let mut wids = WitIdsToIndices::default();
+        self.encode_types(&mut writer, &mut wids);
+        self.encode_imports(&mut writer, &mut wids);
+        self.encode_funcs(&mut writer, &mut wids, indices);
+        self.encode_exports(&mut writer, &wids);
+        self.encode_implements(&mut writer, &wids, indices);
+        writer.into_payload().into()
+    }
+
+    fn gc_add_roots(&self, roots: &mut Roots) {
+        for i in self.implements.iter() {
+            roots.push_func(i.core_func);
+        }
+        for f in self.funcs.iter() {
+            let instrs = match &f.kind {
+                FuncKind::Local(instrs) => instrs,
+                _ => continue,
+            };
+            for instr in instrs {
+                match instr {
+                    Instruction::CallCore(f) | Instruction::DeferCallCore(f) => {
+                        roots.push_func(*f);
+                    }
+                    Instruction::MemoryToString(mem) => {
+                        roots.push_memory(*mem);
+                    }
+                    Instruction::StringToMemory { mem, malloc } => {
+                        roots.push_memory(*mem).push_func(*malloc);
+                    }
+                    _ => {}
+                }
+            }
+        }
+    }
+}
+
+#[derive(Default)]
+struct WitIndicesToIds {
+    types: Vec<TypeId>,
+    funcs: Vec<FuncId>,
+}
+
+impl WitIndicesToIds {
+    fn ty(&self, ty: u32) -> Result<TypeId> {
+        self.types
+            .get(ty as usize)
+            .cloned()
+            .ok_or_else(|| anyhow!("adapter type index out of bounds: {}", ty))
+    }
+
+    fn func(&self, ty: u32) -> Result<FuncId> {
+        self.funcs
+            .get(ty as usize)
+            .cloned()
+            .ok_or_else(|| anyhow!("adapter func index out of bounds: {}", ty))
+    }
+}
+
+#[derive(Default)]
+struct WitIdsToIndices {
+    types: HashMap<TypeId, u32>,
+    funcs: HashMap<FuncId, u32>,
+}
+
+impl WitIdsToIndices {
+    fn push_ty(&mut self, ty: TypeId) {
+        self.types.insert(ty, self.types.len() as u32);
+    }
+
+    fn ty(&self, ty: TypeId) -> u32 {
+        self.types
+            .get(&ty)
+            .cloned()
+            .unwrap_or_else(|| panic!("reference to dead type found {:?}", ty))
+    }
+
+    fn push_func(&mut self, func: FuncId) {
+        self.funcs.insert(func, self.funcs.len() as u32);
+    }
+
+    fn func(&self, f: FuncId) -> u32 {
+        self.funcs
+            .get(&f)
+            .cloned()
+            .unwrap_or_else(|| panic!("reference to dead function found {:?}", f))
+    }
+}
+
+/// Callback for the `ModuleConfig::on_parse` function in `walrus` to act as a
+/// convenience to parse the wasm interface types custom section, if present.
+pub fn on_parse(module: &mut Module, ids: &IndicesToIds) -> Result<()> {
+    let section = match module.customs.remove_raw(SECTION_NAME) {
+        Some(s) => s,
+        None => return Ok(()),
+    };
+    let mut parser = wit_parser::Parser::new(0, &section.data)
+        .context("failed parsing wasm interface types header")?;
+    let mut section = WasmInterfaceTypes::default();
+    let mut wids = WitIndicesToIds::default();
+    while !parser.is_empty() {
+        let s = parser
+            .section()
+            .context("failed parsing wasm interface types section header")?;
+        match s {
+            wit_parser::Section::Type(t) => section.parse_types(t, &mut wids)?,
+            wit_parser::Section::Import(t) => section.parse_imports(t, &mut wids)?,
+            wit_parser::Section::Func(t) => section.parse_funcs(t, ids, &mut wids)?,
+            wit_parser::Section::Implement(t) => section.parse_implements(t, ids, &mut wids)?,
+            wit_parser::Section::Export(t) => section.parse_exports(t, &mut wids)?,
+        }
+    }
+
+    module.customs.add(section);
+    Ok(())
+}

--- a/crates/walrus/src/types.rs
+++ b/crates/walrus/src/types.rs
@@ -1,0 +1,159 @@
+use crate::{WasmInterfaceTypes, WitIdsToIndices, WitIndicesToIds};
+use anyhow::Result;
+use id_arena::{Arena, Id};
+
+#[derive(Debug, Default)]
+pub struct Types {
+    arena: Arena<Type>,
+}
+
+#[derive(Debug)]
+pub struct Type {
+    id: TypeId,
+    params: Box<[ValType]>,
+    results: Box<[ValType]>,
+}
+
+pub type TypeId = Id<Type>;
+
+#[derive(Debug, Copy, Clone)]
+pub enum ValType {
+    S8,
+    S16,
+    S32,
+    S64,
+    U8,
+    U16,
+    U32,
+    U64,
+    F32,
+    F64,
+    String,
+}
+
+impl WasmInterfaceTypes {
+    pub(crate) fn parse_types(
+        &mut self,
+        types: wit_parser::Types,
+        wids: &mut WitIndicesToIds,
+    ) -> Result<()> {
+        for ty in types {
+            let ty = ty?;
+            let id = self.types.add(
+                ty.params.iter().cloned().map(parse2walrus).collect(),
+                ty.results.iter().cloned().map(parse2walrus).collect(),
+            );
+            wids.types.push(id);
+        }
+        Ok(())
+    }
+
+    pub(crate) fn encode_types(&self, writer: &mut wit_writer::Writer, wids: &mut WitIdsToIndices) {
+        let mut w = writer.types(self.types.arena.len() as u32);
+        for (id, ty) in self.types.arena.iter() {
+            w.add(
+                ty.params.len() as u32,
+                |w| {
+                    for param in ty.params.iter() {
+                        write_ty(w, param);
+                    }
+                },
+                ty.results.len() as u32,
+                |w| {
+                    for result in ty.results.iter() {
+                        write_ty(w, result);
+                    }
+                },
+            );
+            wids.push_ty(id);
+        }
+
+        fn write_ty(w: &mut wit_writer::Type<'_>, ty: &ValType) {
+            match ty {
+                ValType::S8 => w.s8(),
+                ValType::S16 => w.s16(),
+                ValType::S32 => w.s32(),
+                ValType::S64 => w.s64(),
+                ValType::U8 => w.u8(),
+                ValType::U16 => w.u16(),
+                ValType::U32 => w.u32(),
+                ValType::U64 => w.u64(),
+                ValType::F32 => w.f32(),
+                ValType::F64 => w.f64(),
+                ValType::String => w.string(),
+            }
+        }
+    }
+}
+
+fn parse2walrus(parse: wit_parser::ValType) -> ValType {
+    match parse {
+        wit_parser::ValType::S8 => ValType::S8,
+        wit_parser::ValType::S16 => ValType::S16,
+        wit_parser::ValType::S32 => ValType::S32,
+        wit_parser::ValType::S64 => ValType::S64,
+        wit_parser::ValType::U8 => ValType::U8,
+        wit_parser::ValType::U16 => ValType::U16,
+        wit_parser::ValType::U32 => ValType::U32,
+        wit_parser::ValType::U64 => ValType::U64,
+        wit_parser::ValType::F32 => ValType::F32,
+        wit_parser::ValType::F64 => ValType::F64,
+        wit_parser::ValType::String => ValType::String,
+    }
+}
+
+impl Types {
+    /// Gets a reference to an type given its id
+    pub fn get(&self, id: TypeId) -> &Type {
+        &self.arena[id]
+    }
+
+    /// Gets a reference to an type given its id
+    pub fn get_mut(&mut self, id: TypeId) -> &mut Type {
+        &mut self.arena[id]
+    }
+
+    // /// Removes an type from this module.
+    // ///
+    // /// It is up to you to ensure that any potential references to the deleted
+    // /// type are also removed, eg `get_global` expressions.
+    // pub fn delete(&mut self, id: TypeId) {
+    //     self.arena.delete(id);
+    // }
+
+    /// Get a shared reference to this section's types.
+    pub fn iter(&self) -> impl Iterator<Item = &Type> {
+        self.arena.iter().map(|(_, f)| f)
+    }
+
+    /// Get mutable references to this section's types.
+    pub fn iter_mut(&mut self) -> impl Iterator<Item = &mut Type> {
+        self.arena.iter_mut().map(|(_, f)| f)
+    }
+
+    /// Adds a new type to this section
+    pub fn add(&mut self, params: Vec<ValType>, results: Vec<ValType>) -> TypeId {
+        self.arena.alloc_with_id(|id| Type {
+            id,
+            params: params.into_boxed_slice(),
+            results: results.into_boxed_slice(),
+        })
+    }
+}
+
+impl Type {
+    /// Returns the identifier for this `Type`
+    pub fn id(&self) -> TypeId {
+        self.id
+    }
+
+    /// Returns parameters of this function type
+    pub fn params(&self) -> &[ValType] {
+        &self.params
+    }
+
+    /// Returns results of this function type
+    pub fn results(&self) -> &[ValType] {
+        &self.results
+    }
+}

--- a/crates/writer/Cargo.toml
+++ b/crates/writer/Cargo.toml
@@ -1,11 +1,9 @@
 [package]
-name = "wit-validator"
+name = "wit-writer"
 version = "0.1.0"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 edition = "2018"
 
 [dependencies]
-anyhow = "1.0"
-wasmparser = "0.42"
-wit-parser = { path = "../parser" }
 wit-schema-version = { path = "../schema-version" }
+leb128 = "0.2"

--- a/crates/writer/src/lib.rs
+++ b/crates/writer/src/lib.rs
@@ -1,0 +1,401 @@
+//! A crate to write the raw wasm interface types section.
+
+#![deny(missing_docs)]
+
+use std::mem;
+
+/// A structure used to write out the raw representation of a wasm interface
+/// types subsection.
+///
+/// This type performs no validation as items are written, but if you're just
+/// calling the methods of this writer you should always produce a syntatically
+/// valid section at least.
+pub struct Writer {
+    dst: Vec<u8>,
+    tmp: Vec<Vec<u8>>,
+}
+
+impl Writer {
+    /// Returns a new `Writer` ready for encoding a wasm interface types section.
+    pub fn new() -> Writer {
+        let mut w = Writer {
+            dst: Vec::new(),
+            tmp: Vec::new(),
+        };
+        wit_schema_version::VERSION.encode(&mut w.dst);
+        return w;
+    }
+
+    /// Returns a section writer used to write out the type subsection of a
+    /// wasm interface types section.
+    pub fn types(&mut self, cnt: u32) -> Types<'_> {
+        Types {
+            tmp: self.start_section(cnt),
+            dst: self,
+        }
+    }
+
+    /// Returns a section writer used to write out the import subsection of a
+    /// wasm interface types section.
+    pub fn imports(&mut self, cnt: u32) -> Imports<'_> {
+        Imports {
+            tmp: self.start_section(cnt),
+            dst: self,
+        }
+    }
+
+    /// Returns a section writer used to write out the function subsection of a
+    /// wasm interface types section.
+    pub fn funcs(&mut self, cnt: u32) -> Funcs<'_> {
+        Funcs {
+            tmp: self.start_section(cnt),
+            dst: self,
+        }
+    }
+
+    /// Returns a section writer used to write out the export subsection of a
+    /// wasm interface types section.
+    pub fn exports(&mut self, cnt: u32) -> Exports<'_> {
+        Exports {
+            tmp: self.start_section(cnt),
+            dst: self,
+        }
+    }
+
+    /// Returns a section writer used to write out the implements subsection of a
+    /// wasm interface types section.
+    pub fn implements(&mut self, cnt: u32) -> Implements<'_> {
+        Implements {
+            tmp: self.start_section(cnt),
+            dst: self,
+        }
+    }
+
+    /// Consumes this writer, returning all bytes written so far.
+    ///
+    /// This will only return the payload of the wasm interface types custom
+    /// section, not the custom section headers.
+    pub fn into_payload(self) -> Vec<u8> {
+        self.dst
+    }
+
+    /// Consumes this writer, returning all bytes written so far.
+    pub fn into_custom_section(mut self) -> Vec<u8> {
+        let mut tmp = self.pop_tmp();
+        wit_schema_version::SECTION_NAME.encode(&mut tmp);
+        tmp.extend_from_slice(&self.dst);
+        let mut tmp2 = self.pop_tmp();
+        tmp2.push(0);
+        tmp.encode(&mut tmp2);
+        return tmp2;
+    }
+
+    fn pop_tmp(&mut self) -> Vec<u8> {
+        self.tmp.pop().unwrap_or(Vec::new())
+    }
+
+    fn push_tmp(&mut self, mut tmp: Vec<u8>) {
+        tmp.truncate(0);
+        self.tmp.push(tmp);
+    }
+
+    fn start_section(&mut self, cnt: u32) -> Vec<u8> {
+        let mut buf = self.pop_tmp();
+        if cnt > 0 {
+            cnt.encode(&mut buf);
+        }
+        buf
+    }
+
+    fn finish_section(&mut self, id: u8, data: Vec<u8>) {
+        if data.len() > 0 {
+            self.dst.push(id);
+            data.encode(&mut self.dst);
+        }
+        self.push_tmp(data);
+    }
+}
+
+/// Writer for the list of types in a type subsection.
+pub struct Types<'a> {
+    dst: &'a mut Writer,
+    tmp: Vec<u8>,
+}
+
+impl Types<'_> {
+    /// Adds a new type in this type section.
+    ///
+    /// The `nparams` argument specifies how many types will be written by the
+    /// `params` closure, and the `nresults argument lists how many times the
+    /// `results` closure will write out a type.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `params` or `results` doesn't write out the same number of
+    /// types that are specified.
+    pub fn add(
+        &mut self,
+        nparams: u32,
+        params: impl FnOnce(&mut Type<'_>),
+        nresults: u32,
+        results: impl FnOnce(&mut Type<'_>),
+    ) {
+        let mut t = Type {
+            dst: &mut self.tmp,
+            cnt: 0,
+        };
+        nparams.encode(t.dst);
+        params(&mut t);
+        assert_eq!(nparams, t.cnt);
+        t.cnt = 0;
+        nresults.encode(t.dst);
+        results(&mut t);
+        assert_eq!(nresults, t.cnt);
+    }
+}
+
+impl Drop for Types<'_> {
+    fn drop(&mut self) {
+        self.dst
+            .finish_section(0x00, mem::replace(&mut self.tmp, Vec::new()));
+    }
+}
+
+/// A writer to write out a type, or a sequence of types.
+pub struct Type<'a> {
+    cnt: u32,
+    dst: &'a mut Vec<u8>,
+}
+
+#[allow(missing_docs)]
+#[rustfmt::skip]
+impl Type<'_> {
+    fn ty(&mut self, byte: u8) {
+        self.cnt += 1;
+        self.dst.push(byte);
+    }
+
+    pub fn s8(&mut self) { self.ty(0x00) }
+    pub fn s16(&mut self) { self.ty(0x01) }
+    pub fn s32(&mut self) { self.ty(0x02) }
+    pub fn s64(&mut self) { self.ty(0x03) }
+    pub fn u8(&mut self) { self.ty(0x04) }
+    pub fn u16(&mut self) { self.ty(0x05) }
+    pub fn u32(&mut self) { self.ty(0x06) }
+    pub fn u64(&mut self) { self.ty(0x07) }
+    pub fn f32(&mut self) { self.ty(0x08) }
+    pub fn f64(&mut self) { self.ty(0x09) }
+    pub fn string(&mut self) { self.ty(0x0a) }
+}
+
+/// Writer for the list of imports in an import subsection.
+pub struct Imports<'a> {
+    dst: &'a mut Writer,
+    tmp: Vec<u8>,
+}
+
+impl Imports<'_> {
+    /// Adds a new import in this type section.
+    pub fn add(&mut self, module: &str, name: &str, ty: u32) {
+        module.encode(&mut self.tmp);
+        name.encode(&mut self.tmp);
+        ty.encode(&mut self.tmp);
+    }
+}
+
+impl Drop for Imports<'_> {
+    fn drop(&mut self) {
+        self.dst
+            .finish_section(0x01, mem::replace(&mut self.tmp, Vec::new()));
+    }
+}
+
+/// Writer for the list of functions in an function subsection.
+pub struct Funcs<'a> {
+    dst: &'a mut Writer,
+    tmp: Vec<u8>,
+}
+
+impl<'a> Funcs<'a> {
+    /// Adds a new function in this type section.
+    pub fn add(&mut self, ty: u32) -> Instructions<'a, '_> {
+        let mut dst = self.dst.pop_tmp();
+        ty.encode(&mut dst);
+        Instructions {
+            tmp: dst,
+            funcs: self,
+        }
+    }
+}
+
+impl Drop for Funcs<'_> {
+    fn drop(&mut self) {
+        self.dst
+            .finish_section(0x02, mem::replace(&mut self.tmp, Vec::new()));
+    }
+}
+
+/// Writer for a sequence of instructions in a function subsection
+pub struct Instructions<'a, 'b> {
+    tmp: Vec<u8>,
+    funcs: &'b mut Funcs<'a>,
+}
+
+#[allow(missing_docs)]
+#[rustfmt::skip]
+impl Instructions<'_, '_> {
+    pub fn arg_get(&mut self, arg: u32) {
+        self.tmp.push(0x00);
+        arg.encode(&mut self.tmp);
+    }
+
+    pub fn call_core(&mut self, func: u32) {
+        self.tmp.push(0x01);
+        func.encode(&mut self.tmp);
+    }
+
+    pub fn memory_to_string(&mut self, mem: u32) {
+        self.tmp.push(0x03);
+        mem.encode(&mut self.tmp);
+    }
+
+    pub fn string_to_memory(&mut self, malloc: u32, mem: u32) {
+        self.tmp.push(0x04);
+        malloc.encode(&mut self.tmp);
+        mem.encode(&mut self.tmp);
+    }
+
+    pub fn call_adapter(&mut self, func: u32) {
+        self.tmp.push(0x05);
+        func.encode(&mut self.tmp);
+    }
+
+    pub fn defer_call_core(&mut self, func: u32) {
+        self.tmp.push(0x06);
+        func.encode(&mut self.tmp);
+    }
+
+    pub fn i32_to_s8(&mut self) { self.tmp.push(0x07) }
+    pub fn i32_to_s8x(&mut self) { self.tmp.push(0x08) }
+    pub fn i32_to_u8(&mut self) { self.tmp.push(0x09) }
+    pub fn i32_to_s16(&mut self) { self.tmp.push(0x0a) }
+    pub fn i32_to_s16x(&mut self) { self.tmp.push(0x0b) }
+    pub fn i32_to_u16(&mut self) { self.tmp.push(0x0c) }
+    pub fn i32_to_s32(&mut self) { self.tmp.push(0x0d) }
+    pub fn i32_to_u32(&mut self) { self.tmp.push(0x0e) }
+    pub fn i32_to_s64(&mut self) { self.tmp.push(0x0f) }
+    pub fn i32_to_u64(&mut self) { self.tmp.push(0x10) }
+
+    pub fn i64_to_s8(&mut self) { self.tmp.push(0x11) }
+    pub fn i64_to_s8x(&mut self) { self.tmp.push(0x12) }
+    pub fn i64_to_u8(&mut self) { self.tmp.push(0x13) }
+    pub fn i64_to_s16(&mut self) { self.tmp.push(0x14) }
+    pub fn i64_to_s16x(&mut self) { self.tmp.push(0x15) }
+    pub fn i64_to_u16(&mut self) { self.tmp.push(0x16) }
+    pub fn i64_to_s32(&mut self) { self.tmp.push(0x17) }
+    pub fn i64_to_s32x(&mut self) { self.tmp.push(0x18) }
+    pub fn i64_to_u32(&mut self) { self.tmp.push(0x19) }
+    pub fn i64_to_s64(&mut self) { self.tmp.push(0x1a) }
+    pub fn i64_to_u64(&mut self) { self.tmp.push(0x1b) }
+
+    pub fn s8_to_i32(&mut self) { self.tmp.push(0x1c) }
+    pub fn u8_to_i32(&mut self) { self.tmp.push(0x1d) }
+    pub fn s16_to_i32(&mut self) { self.tmp.push(0x1e) }
+    pub fn u16_to_i32(&mut self) { self.tmp.push(0x1f) }
+    pub fn s32_to_i32(&mut self) { self.tmp.push(0x20) }
+    pub fn u32_to_i32(&mut self) { self.tmp.push(0x21) }
+    pub fn s64_to_i32(&mut self) { self.tmp.push(0x22) }
+    pub fn s64_to_i32x(&mut self) { self.tmp.push(0x23) }
+    pub fn u64_to_i32(&mut self) { self.tmp.push(0x24) }
+    pub fn u64_to_i32x(&mut self) { self.tmp.push(0x25) }
+
+    pub fn s8_to_i64(&mut self) { self.tmp.push(0x26) }
+    pub fn u8_to_i64(&mut self) { self.tmp.push(0x27) }
+    pub fn s16_to_i64(&mut self) { self.tmp.push(0x28) }
+    pub fn u16_to_i64(&mut self) { self.tmp.push(0x29) }
+    pub fn s32_to_i64(&mut self) { self.tmp.push(0x2a) }
+    pub fn u32_to_i64(&mut self) { self.tmp.push(0x2b) }
+    pub fn s64_to_i64(&mut self) { self.tmp.push(0x2c) }
+    pub fn u64_to_i64(&mut self) { self.tmp.push(0x2d) }
+}
+
+impl Drop for Instructions<'_, '_> {
+    fn drop(&mut self) {
+        self.tmp.push(0x02);
+        let buf = mem::replace(&mut self.tmp, Vec::new());
+        buf.encode(&mut self.funcs.tmp);
+        self.funcs.dst.push_tmp(buf);
+    }
+}
+
+/// Writer for the list of exports in an export subsection.
+pub struct Exports<'a> {
+    dst: &'a mut Writer,
+    tmp: Vec<u8>,
+}
+
+impl Exports<'_> {
+    /// Adds a new export in this type section.
+    pub fn add(&mut self, name: &str, func: u32) {
+        func.encode(&mut self.tmp);
+        name.encode(&mut self.tmp);
+    }
+}
+
+impl Drop for Exports<'_> {
+    fn drop(&mut self) {
+        self.dst
+            .finish_section(0x03, mem::replace(&mut self.tmp, Vec::new()));
+    }
+}
+
+/// Writer for the list of imports in an import subsection.
+pub struct Implements<'a> {
+    dst: &'a mut Writer,
+    tmp: Vec<u8>,
+}
+
+impl Implements<'_> {
+    /// Adds a new import in this type section.
+    pub fn add(&mut self, core_func: u32, adapter_func: u32) {
+        core_func.encode(&mut self.tmp);
+        adapter_func.encode(&mut self.tmp);
+    }
+}
+
+impl Drop for Implements<'_> {
+    fn drop(&mut self) {
+        self.dst
+            .finish_section(0x04, mem::replace(&mut self.tmp, Vec::new()));
+    }
+}
+
+trait Encode {
+    fn encode(&self, e: &mut Vec<u8>);
+}
+
+impl Encode for [u8] {
+    fn encode(&self, e: &mut Vec<u8>) {
+        self.len().encode(e);
+        e.extend_from_slice(self);
+    }
+}
+
+impl Encode for str {
+    fn encode(&self, e: &mut Vec<u8>) {
+        self.as_bytes().encode(e);
+    }
+}
+
+impl Encode for usize {
+    fn encode(&self, e: &mut Vec<u8>) {
+        assert!(*self <= u32::max_value() as usize);
+        (*self as u32).encode(e)
+    }
+}
+
+impl Encode for u32 {
+    fn encode(&self, e: &mut Vec<u8>) {
+        leb128::write::unsigned(e, (*self).into()).unwrap();
+    }
+}


### PR DESCRIPTION
This commit does quite a few things:

* Add a new `wit-writer` crate which is intended to be a very low-level
  interface for writing the wasm interface types custom section. This is
  hoped to handle all the nitty-gritty of encoding and other libraries
  can simply use it and not worry about a class of malformed binary
  errors.

* Refactor the `wit-text` crate to use the `wit-writer` crate now that
  it exists.

* Add a new `wit-walrus` crate. This crate is intended as an advanced IR
  for transformations over the wasm interface types section, such as
  what `wasm-bindgen` is predicted to do.